### PR TITLE
feat(api): add API endpoint "/images"

### DIFF
--- a/main.js
+++ b/main.js
@@ -22,9 +22,11 @@ function requestLogger(req, _, next) {
 app.use(requestLogger);
 
 const rankingRouter = new RankingRouter();
+const imageRouter = new ImageRouter();
 // app.use('/groups', GroupRouter);
 app.use('/groups/:groupId/rank', rankingRouter.getRouter());
 app.use('/groups/:groupId/participants', userRouter);
+app.use('/images', imageRouter.getRouter());
 
 // 전역 에러 핸들러 미들웨어
 // 반드시 모든 라우터 뒤에 위치해야 합니다.

--- a/src/controller/ImageController.js
+++ b/src/controller/ImageController.js
@@ -1,0 +1,26 @@
+import ImageService from '../service/ImageService.js';
+
+export default class ImageController {
+  constructor() {
+    this.imageService = new ImageService();
+  }
+
+  getImage = async (req, res, next) => {
+    if (req.files) {
+      // console.log(req.files);
+      const files = req.files.map(f => ({
+        name: f.originalname,
+        path: f.path,
+      }));
+      // console.log(files);
+
+      const urls = await this.imageService.getUrls(files);
+
+      res.status(200).json({ urls });
+    } else {
+      return res.status(400).json({
+        message: 'File should be an image file',
+      });
+    }
+  };
+}

--- a/src/repository/ImageRepository.js
+++ b/src/repository/ImageRepository.js
@@ -1,0 +1,14 @@
+import { PrismaClient } from "@prisma/client";
+
+export default class ImageRepository {
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
+
+  insertMetadata = async (files) => {
+    return await this.prisma.image.createMany({
+      data: files,
+      skipDuplicates: true,
+    });
+  }
+}

--- a/src/router/ImageRouter.js
+++ b/src/router/ImageRouter.js
@@ -6,7 +6,18 @@ export default class ImageRouter {
   constructor() {
     this.router = express.Router({ mergeParams: true });
     this.imageController = new ImageController();
-    this.upload = multer({ dest: 'uploads/' });
+    this.upload = multer({
+      dest: 'uploads/',
+      fileFilter: (req, file, cb) => {
+        if (file.mimetype.startsWith('image/')) {
+          cb(null, true); // 이미지면 통과
+        } else {
+          const error = new Error('File should be an image file'); // 이미지가 아니면 에러 발생
+          err.statusCode = 400; 
+          cb(error,false)
+        }
+      },
+    });
 
     this.initializeRouter();
   }

--- a/src/router/ImageRouter.js
+++ b/src/router/ImageRouter.js
@@ -1,0 +1,26 @@
+import express from 'express';
+import ImageController from '../controller/ImageController.js';
+import multer from 'multer';
+
+export default class ImageRouter {
+  constructor() {
+    this.router = express.Router({ mergeParams: true });
+    this.imageController = new ImageController();
+    this.upload = multer({ dest: 'uploads/' });
+
+    this.initializeRouter();
+  }
+
+  initializeRouter() {
+    this.router
+      .route('/')
+      .post(
+        this.upload.array('images', 5),
+        this.imageController.getImage.bind(this.imageController),
+      );
+  }
+
+  getRouter() {
+    return this.router;
+  }
+}

--- a/src/service/ImageService.js
+++ b/src/service/ImageService.js
@@ -1,0 +1,13 @@
+import ImageRepository from '../repository/ImageRepository.js';
+
+export default class ImageService {
+  constructor() {
+    this.imageRepository = new ImageRepository();
+  }
+
+  getUrls = async (files) => {
+    await this.imageRepository.insertMetadata(files);
+    
+    return files.map((f) => f.path);
+  }
+}

--- a/src/service/ImageService.js
+++ b/src/service/ImageService.js
@@ -8,6 +8,6 @@ export default class ImageService {
   getUrls = async (files) => {
     await this.imageRepository.insertMetadata(files);
     
-    return files.map((f) => f.path);
+    return files.map((f) => `http://localhost:${process.env.PORT}/` + f.path);
   }
 }


### PR DESCRIPTION
### What
이미지 업로드를 위한 엔드포인트 `/images`가 추가되었습니다.

### Why
이미지 업로드 API 엔드포인트 추가 위함

### How to test
<img width="1364" height="754" alt="Screenshot 2025-08-19 at 11 25 24" src="https://github.com/user-attachments/assets/4b08f966-da4b-4910-8ae8-932c0799b640" />

### Additional info (optional)
- 글로벌 에러 핸들러와 클래스 인스턴스 생성 부분, prismaClient의 객체 공유는 추후 별개의 PR로 통합 예정