### PR TITLE
fix: hotfix for serving static image routes and change multer field

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,6 +52,9 @@ app.use('/api', recordsRouter(recordsController));
 app.use('/tags', tagRouter);
 app.use('/groups/:groupId/likes', likeRouter);
 
+// 이미지 파일 정적 제공
+app.use('/uploads', express.static('uploads'));
+
 // 전역 에러 핸들러 미들웨어
 // 반드시 모든 라우터 뒤에 위치해야 합니다.
 app.use((err, req, res, next) => {

--- a/src/router/ImageRouter.js
+++ b/src/router/ImageRouter.js
@@ -26,7 +26,7 @@ export default class ImageRouter {
     this.router
       .route('/')
       .post(
-        this.upload.array('images', 5),
+        this.upload.array('files', 5),
         this.imageController.getImage.bind(this.imageController),
       );
   }


### PR DESCRIPTION
### What
- `main.js`에서 /uploads 경로 아래의 파일들을 정적 제공하도록 변경
- multer의 업로드 필드를 images에서 files로 수정

### Why
프론트단에서 서버로부터 받아온 이미지 경로를 정상적으로 출력하기 위해 필요

### How to test


### Additional info (optional)