### PR TITLE
feat(api): Separate all groups of users into owners and participants

### DIFF
--- a/src/service/user-service.js
+++ b/src/service/user-service.js
@@ -50,6 +50,27 @@ export class UserService {
     };
   };
 
+  userSeperateForAllGroups = async (groupArray) => {
+    return groupArray.map((groupData) => {
+      const { user, ...groupInfo } = groupData;
+
+      const userToSeperate = [...user];
+
+      const ownerArray = userToSeperate.filter((u) => u.auth_code === 'OWNER');
+      const participants = userToSeperate.filter(
+        (u) => u.auth_code === 'PARTICIPANTS',
+      );
+
+      const owner = ownerArray[0]; // OWNER는 객체로 반환
+
+      return {
+        ...groupInfo,
+        owner,
+        participants,
+      };
+    });
+  };
+
   leaveParticipantFromGroup = async (nickname, password, groupId) => {
     try {
       const user = await this.userRepository.findUser({

--- a/src/service/user-service.js
+++ b/src/service/user-service.js
@@ -25,19 +25,19 @@ export class UserService {
         );
         return result;
       });
-      return this.userSeperate(updatedGroup);
+      return this.userSeparate(updatedGroup);
     } catch (error) {
       throw error;
     }
   };
 
-  userSeperate = async (groupData) => {
+  userSeparate = async (groupData) => {
     const { user, ...groupInfo } = groupData;
 
-    const userToSeperate = [...user];
+    const userToSeparate = [...user];
 
-    const ownerArray = userToSeperate.filter((u) => u.auth_code === 'OWNER');
-    const participants = userToSeperate.filter(
+    const ownerArray = userToSeparate.filter((u) => u.auth_code === 'OWNER');
+    const participants = userToSeparate.filter(
       (u) => u.auth_code === 'PARTICIPANTS',
     );
 
@@ -50,14 +50,14 @@ export class UserService {
     };
   };
 
-  userSeperateForAllGroups = async (groupArray) => {
+  userSeparateForAllGroups = async (groupArray) => {
     return groupArray.map((groupData) => {
       const { user, ...groupInfo } = groupData;
 
-      const userToSeperate = [...user];
+      const userToSeparate = [...user];
 
-      const ownerArray = userToSeperate.filter((u) => u.auth_code === 'OWNER');
-      const participants = userToSeperate.filter(
+      const ownerArray = userToSeparate.filter((u) => u.auth_code === 'OWNER');
+      const participants = userToSeparate.filter(
         (u) => u.auth_code === 'PARTICIPANTS',
       );
 


### PR DESCRIPTION
## 변경내용

### 기존
- `user-service`에는 하나의 그룹 데이터가 들어올 때 그룹의 사용자를  소유주와 참가자를 분리하는 로직만 존재.

### 변경사항
- 여러 개의 그룹 데이터가 배열의 형태로 들어올 때 그룹들의 각 사용자들을 소유주와 참가자로 분리하여 반환하는 로직 추가